### PR TITLE
127 change color styling for homepage cards and search results cards should be the same

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -23,11 +23,7 @@ body {
 }
 
 .primary-color {
-  background-color: white;
-  border-color: #8e3ac1;
-  border-radius: 5px;
-  height: 50px;
-  width: 50px;
+  background-color: #8e3ac1;
 }
 
 .primary-color-text {
@@ -68,19 +64,23 @@ body {
       .anime-card-title {
         text-align: right;
         z-index: 1;
+        font-weight: bold;
         color: #ffffff;
         max-width: 35rem;
       }
 
       .anime-card-score {
         text-align: right;
+        font-weight: bold;
         color: #a086d2;
         z-index: 1;
       }
     }
 
     .anime-card-btn {
-      background-color: #8e3ac1;
+      background-color: #ffffff;
+      font-weight: bold;
+      color: #8e3ac1;
       transition: 300ms ease all;
     }
 
@@ -100,6 +100,13 @@ body {
   }
 }
 
+#search-btn {
+  background-color: #ffffff;
+  border-color: #8e3ac1;
+  border-radius: 5px;
+  height: 50px;
+  width: 50px;
+}
 
 #search-icon {
   color: #8e3ac1;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9,6 +9,7 @@ body {
 .card-body {
   background-color: #111103;
 }
+
 .short-card-body {
   height: 30%;
 }
@@ -22,7 +23,11 @@ body {
 }
 
 .primary-color {
-  background-color: #8e3ac1;
+  background-color: white;
+  border-color: #8e3ac1;
+  border-radius: 5px;
+  height: 50px;
+  width: 50px;
 }
 
 .primary-color-text {
@@ -89,10 +94,13 @@ body {
     width: 400px;
     top: -30%;
     left: 0;
-    mask-image: linear-gradient(
-      to right,
-      rgba(17, 17, 3, 1),
-      rgba(17, 17, 3, 0)
-    );
+    mask-image: linear-gradient(to right,
+        rgba(17, 17, 3, 1),
+        rgba(17, 17, 3, 0));
   }
+}
+
+
+#search-icon {
+  color: #8e3ac1;
 }

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -110,7 +110,7 @@
         aria-label='Search'
         id='search-input'
       />
-      <button class='btn primary-color' type='submit'><i
+      <button id='search-btn' class='btn primary-color' type='submit'><i
           id='search-icon'
           class='bi bi-search'
         ></i></button>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -110,7 +110,8 @@
         aria-label='Search'
         id='search-input'
       />
-      <button class='btn primary-color text-white' type='submit'><i
+      <button class='btn primary-color' type='submit'><i
+          id='search-icon'
           class='bi bi-search'
         ></i></button>
     </form>


### PR DESCRIPTION
## Purpose

Please provide a detailed explanation of the PR. What existing problem does it solve?
I fixed the css so the text, score, and follow are old bold and follow the same color styling per page. The search icon has a border and also follows the same color styling.
Fixes #127 

## Changes

Please provide an overview of code changes, especially key files and areas of significant change.

- path/to/file
  - public/css/style.css
  - views/layouts/main.handlebars
## Steps to Reproduce or Test

Demonstrate that the pull request is functional. For example: the exact commands to be run and their output; screenshots if the PR modifies the UI.

- clone the branch
- do something else
- do something else

## Optional GIF
![Screenshot 2024-04-18 at 12 44 22 PM](https://github.com/HUGODEHSIGN/my-otaku-opinions/assets/112511355/ab36cfc5-fefd-4d6e-b183-5e7a954b437d)
![Screenshot 2024-04-18 at 12 44 29 PM](https://github.com/HUGODEHSIGN/my-otaku-opinions/assets/112511355/b90dfaeb-41b7-4f96-83dc-b8a6e8fc1c4d)
![Screenshot 2024-04-18 at 12 44 32 PM](https://github.com/HUGODEHSIGN/my-otaku-opinions/assets/112511355/8eb959ff-74e8-42c8-a11b-11e3b9e03d6d)

Self-explanatory.